### PR TITLE
Lower engine requirement for extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "version": "0.0.1",
   "engines": {
-    "vscode": "^1.101.0"
+    "vscode": "^1.80.0"
   },
   "categories": [
     "Formatters"
@@ -36,7 +36,8 @@
     "code style"
   ],
   "activationEvents": [
-    "onLanguage:drl"
+    "onLanguage:drl",
+    "onLanguage:drools"
   ],
   "contributes": {
     "languages": [
@@ -67,7 +68,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.10",
-    "@types/vscode": "^1.101.0",
+    "@types/vscode": "^1.80.0",
     "eslint": "^8.57.0",
     "ts-loader": "^9.5.1",
     "typescript": "^5.8.3",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,10 +21,12 @@ export function activate(context: vscode.ExtensionContext) {
         }
     };
 
-    context.subscriptions.push(
-        vscode.languages.registerDocumentFormattingEditProvider('drl', formatter),
-        vscode.languages.registerDocumentRangeFormattingEditProvider('drl', rangeFormatter)
-    );
+    for (const lang of ['drl', 'drools']) {
+        context.subscriptions.push(
+            vscode.languages.registerDocumentFormattingEditProvider(lang, formatter),
+            vscode.languages.registerDocumentRangeFormattingEditProvider(lang, rangeFormatter)
+        );
+    }
 }
 
 export function deactivate() {}


### PR DESCRIPTION
## Summary
- lower VS Code engine requirement to 1.80
- align `@types/vscode` dependency
- register formatter for both `drl` and `drools` language IDs
- activate on the `drools` language alias

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68697d86f83c8324815fdd420e767a1e