### PR TITLE
Improve drools indentation

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,6 +1,6 @@
 export function formatDrools(text: string): string {
     const lines = text.split(/\r?\n/);
-    let context: 'none' | 'attr' | 'when' | 'then' = 'none';
+    let context: 'none' | 'attr' | 'when' | 'then' | 'query' = 'none';
     const formatted: string[] = [];
     let blockIndent = 0;
 
@@ -25,7 +25,7 @@ export function formatDrools(text: string): string {
 
         removePreSpace();
 
-        if (context === 'when') {
+        if (context === 'when' || context === 'query') {
             addInnerSpaces();
             collapsed = collapsed.replace(/\bnew\s+([A-Za-z0-9_.<>$]+)\(\s*([^)]*?)\s*\)/g, (m, cls, args) => `new ${cls}(${args.trim()})`);
         } else if (context === 'then') {
@@ -58,14 +58,20 @@ export function formatDrools(text: string): string {
             continue;
         }
 
+        if (/^query\b/.test(collapsed)) {
+            formatted.push(collapsed);
+            context = 'query';
+            continue;
+        }
+
         if (collapsed === 'when') {
-            formatted.push('when');
+            formatted.push(pad(blockIndent + 1) + 'when');
             context = 'when';
             continue;
         }
 
         if (collapsed === 'then') {
-            formatted.push('then');
+            formatted.push(pad(blockIndent + 1) + 'then');
             context = 'then';
             continue;
         }
@@ -79,6 +85,9 @@ export function formatDrools(text: string): string {
             indent += 1;
         }
         if (context === 'when' || context === 'then') {
+            indent += 2;
+        }
+        if (context === 'query') {
             indent += 2;
         }
 

--- a/src/test/keywords.test.ts
+++ b/src/test/keywords.test.ts
@@ -12,6 +12,15 @@ const input = [
     'end'
 ].join('\n');
 
-const expected = input;
+const expected = [
+    'rule "R"',
+    '  when',
+    '    true',
+    '    false',
+    '    null',
+    '  then',
+    '    exists',
+    'end'
+].join('\n');
 assert.strictEqual(formatDrools(input), expected);
 console.log('keyword formatting test passed');

--- a/src/test/spacing.test.ts
+++ b/src/test/spacing.test.ts
@@ -10,13 +10,13 @@ const expectedPattern = '$s : String( this == "World" )';
 for (const input of patternInputs) {
     const drl = ['rule "R"', 'when', input, 'then', 'end'].join('\n');
     const expectLine = input.includes('( "World" ) )') ? '$s : String( this == ( "World" ) )' : expectedPattern;
-    const expected = ['rule "R"', 'when', `    ${expectLine}`, 'then', 'end'].join('\n');
+    const expected = ['rule "R"', '  when', `    ${expectLine}`, '  then', 'end'].join('\n');
     assert.strictEqual(formatDrools(drl), expected);
 }
 
 const exprInput = '( $a == 1 ) && ( $b == 2 )';
 const exprDrl = ['rule "R"', 'when', `    ${exprInput}`, 'then', 'end'].join('\n');
-const exprExpected = ['rule "R"', 'when', '    ( $a == 1 ) && ( $b == 2 )', 'then', 'end'].join('\n');
+const exprExpected = ['rule "R"', '  when', '    ( $a == 1 ) && ( $b == 2 )', '  then', 'end'].join('\n');
 assert.strictEqual(formatDrools(exprDrl), exprExpected);
 
 const actionInputs = [
@@ -40,7 +40,7 @@ actionInputs.forEach((input, idx) => {
     } else {
         expectLine = expectedActionLines[0];
     }
-    const expected = ['rule "R"', 'when', '    $s : String()', 'then', `    ${expectLine}`, 'end'].join('\n');
+    const expected = ['rule "R"', '  when', '    $s : String()', '  then', `    ${expectLine}`, 'end'].join('\n');
     assert.strictEqual(formatDrools(drl), expected);
 });
 
@@ -52,12 +52,12 @@ const updateInputs = [
 const expectedUpdate = 'update($app);';
 for (const input of updateInputs) {
     const drl = ['rule "R"', 'when', '    $app : Object()', 'then', `    ${input}`, 'end'].join('\n');
-    const expected = ['rule "R"', 'when', '    $app : Object()', 'then', `    ${expectedUpdate}`, 'end'].join('\n');
+    const expected = ['rule "R"', '  when', '    $app : Object()', '  then', `    ${expectedUpdate}`, 'end'].join('\n');
     assert.strictEqual(formatDrools(drl), expected);
 }
 
 const constructorInput = 'alerts.add( new Alert("INFO", "System started") );';
 const newDrl = ['rule "R"', 'when', '    // Empty', 'then', `    ${constructorInput}`, 'end'].join('\n');
-const newExpected = ['rule "R"', 'when', '    // Empty', 'then', '    alerts.add( new Alert("INFO", "System started") );', 'end'].join('\n');
+const newExpected = ['rule "R"', '  when', '    // Empty', '  then', '    alerts.add( new Alert("INFO", "System started") );', 'end'].join('\n');
 assert.strictEqual(formatDrools(newDrl), newExpected);
 console.log('spacing formatting test passed');


### PR DESCRIPTION
## Summary
- improve indentation logic in `formatDrools`
- keep `new` expressions compact

## Testing
- `npm test`
- `node out/test/spacing.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688ba80efd608324a9ac3e00fd250d43