### PR TITLE
Expand test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "lint": "echo no-lint",
-    "test": "node ./out/test/keywords.test.js"
+    "test": "node ./out/test/keywords.test.js && node ./out/test/spacing.test.js && node ./out/test/attributes.test.js && node ./out/test/query.test.js"
   },
   "devDependencies": {
     "@types/node": "^24.0.10",

--- a/src/test/attributes.test.ts
+++ b/src/test/attributes.test.ts
@@ -1,0 +1,25 @@
+import * as assert from 'assert';
+import { formatDrools } from '../formatter';
+
+const input = [
+    'rule "R"',
+    'dialect "mvel"',
+    'salience 10',
+    'when',
+    '    $s : String()',
+    'then',
+    'end'
+].join('\n');
+
+const expected = [
+    'rule "R"',
+    '  dialect "mvel"',
+    '  salience 10',
+    '  when',
+    '    $s : String()',
+    '  then',
+    'end'
+].join('\n');
+
+assert.strictEqual(formatDrools(input), expected);
+console.log('attribute formatting test passed');

--- a/src/test/query.test.ts
+++ b/src/test/query.test.ts
@@ -1,0 +1,17 @@
+import * as assert from 'assert';
+import { formatDrools } from '../formatter';
+
+const input = [
+    'query adults',
+    '$p : Person(age>=18)',
+    'end'
+].join('\n');
+
+const expected = [
+    'query adults',
+    '    $p : Person( age>=18 )',
+    'end'
+].join('\n');
+
+assert.strictEqual(formatDrools(input), expected);
+console.log('query formatting test passed');


### PR DESCRIPTION
## Summary
- run all test files
- add tests for rule attributes and query indentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bc07538e08324a2ea587ca113864f