### PR TITLE
Added CLI command for the formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ The compiled extension code is output to the `dist` folder.
 Open a `.drl` file in VS Code and use the standard formatting commands.
 The extension registers the `drl` language, so `.drl` files are recognized automatically when the extension is installed.
 
+## CLI Tool
+
+You can also use the formatter directly from the CLI.
+You can install it globally like this:
+
+```
+npm install
+npm run build:cli
+npm install -g .
+```
+
+You can now use `drools-fmt` from anywhere, to see its usage instructions run:
+```
+drools-fmt -h
+```
+
 ## Disclaimer
 
 This extension is an independent project and is not affiliated with or endorsed by the Drools project or Red Hat. The Drools name and logo are trademarks of their respective owners; use here is for identification purposes only.

--- a/package.json
+++ b/package.json
@@ -41,12 +41,17 @@
   "activationEvents": [
     "onLanguage:drools"
   ],
-"contributes": {
+  "contributes": {
     "languages": [
       {
         "id": "drools",
-        "aliases": ["Drools", "drools"],
-        "extensions": [".drl"],
+        "aliases": [
+          "Drools",
+          "drools"
+        ],
+        "extensions": [
+          ".drl"
+        ],
         "configuration": "./language-configuration.json"
       }
     ],
@@ -79,6 +84,9 @@
     }
   },
   "main": "./dist/extension.js",
+  "bin": {
+    "drools-fmt": "./dist/cli.js"
+  },
   "scripts": {
     "vscode:prepublish": "npm run package",
     "compile": "npx webpack",
@@ -88,11 +96,13 @@
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "lint": "echo no-lint",
-    "test": "node ./out/test/keywords.test.js && node ./out/test/spacing.test.js && node ./out/test/attributes.test.js && node ./out/test/query.test.js && node ./out/test/indentation.test.js"
+    "test": "node ./out/test/keywords.test.js && node ./out/test/spacing.test.js && node ./out/test/attributes.test.js && node ./out/test/query.test.js && node ./out/test/indentation.test.js",
+    "build:cli": "esbuild src/cli.ts --bundle --platform=node --outfile=dist/cli.js"
   },
   "devDependencies": {
     "@types/node": "^24.0.10",
     "@types/vscode": "^1.80.0",
+    "esbuild": "^0.27.3",
     "eslint": "^8.57.0",
     "ts-loader": "^9.5.1",
     "typescript": "^5.8.3",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import * as fs from 'fs';
+import * as path from 'path';
+import { formatDrools } from './formatter';
+
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(`
+Usage: drools-fmt [options] [file]
+
+Formats Drools (.drl) rule files.
+
+Arguments:
+  file              Path to a .drl file (omit to read from stdin)
+
+Options:
+  --write           Edit the file in-place instead of printing to stdout
+  --tabs            Use hard tabs instead of spaces (default: spaces)
+  --tab-size=N      Number of spaces per indent level, 1-8 (default: 2)
+  -h, --help        Show this help message
+
+Examples:
+  drools-fmt my_rules.drl
+  drools-fmt --write my_rules.drl
+  drools-fmt --tab-size=4 my_rules.drl
+  drools-fmt < my_rules.drl
+  cat my_rules.drl | drools-fmt
+`.trimStart());
+    process.exit(0);
+}
+
+const insertSpaces = !args.includes('--tabs');
+const tabSizeArg = args.find(a => a.startsWith('--tab-size='));
+const tabSize = tabSizeArg ? parseInt(tabSizeArg.split('=')[1], 10) : 2;
+const writeInPlace = args.includes('--write');
+
+const fileArg = args.find(a => !a.startsWith('--'));
+
+function format(input: string): void {
+    const result = formatDrools(input, { insertSpaces, tabSize });
+    if (writeInPlace && fileArg) {
+        fs.writeFileSync(fileArg, result, 'utf8');
+        process.stderr.write(`Formatted ${path.resolve(fileArg)}\n`);
+    } else {
+        process.stdout.write(result);
+    }
+}
+
+if (fileArg) {
+    if (!fs.existsSync(fileArg)) {
+        process.stderr.write(`Error: file not found: ${fileArg}\n`);
+        process.exit(1);
+    }
+    format(fs.readFileSync(fileArg, 'utf8'));
+} else {
+    let input = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => { input += chunk; });
+    process.stdin.on('end', () => format(input));
+}


### PR DESCRIPTION
This adds a `drools-fmt` command that can be used from the CLI and from editors like Neovim or Helix through stdin:

---

**Usage**: drools-fmt [options] [file]
Formats Drools (.drl) rule files.

**Arguments**:
  Path to a .drl file (omit to read from stdin)
  
**Options**:
  --write
  Edit the file in-place instead of printing to stdout

  --tabs
Use hard tabs instead of spaces (default: spaces)

  --tab-size=N
Number of spaces per indent level, 1-8 (default: 2)

  -h, --help
Show this help message
  
**Examples**:
  drools-fmt my_rules.drl
  drools-fmt --write my_rules.drl
  drools-fmt --tab-size=4 my_rules.drl
  drools-fmt < my_rules.drl
  cat my_rules.drl | drools-fmt